### PR TITLE
MSINT-6135 Updated the SWIG bindings to expose the C++ function OGRSpatialReference#FindBestMatch() that was added in GDAL 3.6.0

### DIFF
--- a/ogr/ogr_srs_api.h
+++ b/ogr/ogr_srs_api.h
@@ -637,6 +637,12 @@ OGRSpatialReferenceH CPL_DLL *OSRFindMatches(OGRSpatialReferenceH hSRS,
                                              char **papszOptions,
                                              int *pnEntries,
                                              int **ppanMatchConfidence);
+OGRSpatialReferenceH CPL_DLL OSRFindBestMatch(OGRSpatialReferenceH hSRS,
+                                             char **papszOptions,
+                                             char *pszPreferredAuthority,
+                                             int nMinimumMatchConfidence);
+
+
 void CPL_DLL OSRFreeSRSArray(OGRSpatialReferenceH *pahSRS);
 
 int CPL_DLL OSREPSGTreatsAsLatLong(OGRSpatialReferenceH hSRS);

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -9528,6 +9528,44 @@ OGRSpatialReferenceH *OSRFindMatches(OGRSpatialReferenceH hSRS,
 }
 
 /************************************************************************/
+/*                           OSRFindBestMatch()                           */
+/************************************************************************/
+
+/**
+ * \brief Try to identify the best match between the passed SRS and a related
+ * SRS in a catalog.
+ *
+ * This is a wrapper over OGRSpatialReference::FindMatches() that takes care
+ * of filtering its output.
+ * Only matches whose confidence is greater or equal to nMinimumMatchConfidence
+ * will be considered. If there is a single match, it is returned.
+ * If there are several matches, only return the one under the
+ * pszPreferredAuthority, if there is a single one under that authority.
+ *
+ * This function is the same as OGRSpatialReference::FindBestMatch().
+ *
+ * @param hSRS SRS to match
+ * @param nMinimumMatchConfidence Minimum match confidence (value between 0 and
+ * 100). If set to 0, 90 is used.
+ * @param pszPreferredAuthority Preferred CRS authority. If set to nullptr,
+ * "EPSG" is used.
+ * @param papszOptions NULL terminated list of options or NULL. No option is
+ * defined at time of writing.
+ *
+ * @return a new OGRSpatialReference* object to free with Release(), or nullptr
+ *
+ * @since GDAL 3.6
+ */
+OGRSpatialReferenceH OSRFindBestMatch(OGRSpatialReferenceH hSRS,
+                                     char **papszOptions, char *pszPreferredAuthority,
+                                     int nMinimumMatchConfidence)
+{
+    VALIDATE_POINTER1(hSRS, "OSRFindBestMatch", nullptr);
+
+    return ToHandle(ToPointer(hSRS)->FindBestMatch(nMinimumMatchConfidence, pszPreferredAuthority, papszOptions));
+}
+
+/************************************************************************/
 /*                           OSRFreeSRSArray()                          */
 /************************************************************************/
 

--- a/swig/include/osr.i
+++ b/swig/include/osr.i
@@ -575,6 +575,11 @@ public:
   }
 #endif
 
+%newobject FindBestMatch;
+  OSRSpatialReferenceShadow *FindBestMatch(char *preferredAuthority = NULL, int minimumMatchConfidence = 0, char **options = NULL) {
+    return (OSRSpatialReferenceShadow *) OSRFindBestMatch(self, options, preferredAuthority, minimumMatchConfidence);
+  }
+
   OGRErr SetProjection( char const *arg ) {
     return OSRSetProjection( self, arg );
   }


### PR DESCRIPTION
- Updated ogr_srs_api.h to expose a new wrapper function, OSRFindBestMatch, for SWIG to invoke. 
- Updated ogrspatialreference.cpp to implement the new wrapper function which invokes the existing FindBestMatch while handling the relevant pointers. 
- Updated osr.i to include a new SWIG binding on the new OSRFindBestMatch wrapper function to allow Java and Python clients to invoke FindBestMatch on spatial reference instances.
